### PR TITLE
Schema version upward support

### DIFF
--- a/RedfishClientPkg/Include/Library/EdkIIRedfishResourceConfigLib.h
+++ b/RedfishClientPkg/Include/Library/EdkIIRedfishResourceConfigLib.h
@@ -192,4 +192,25 @@ GetSupportedSchemaVersion (
   OUT  REDFISH_SCHEMA_INFO  *SchemaInfo
   );
 
+/**
+  This function checks the schema version in InputJson to see if it matches
+  SchemaInfo. If not, it will replace "@odata.type" value to the schema information
+  provided by SchemaInfo. It's call's responsibility to release OutputJson by calling
+  FreePool().
+
+  @param[in]  SchemaInfo          Desired schema information.
+  @param[in]  InputJson           JSON data on input.
+  @param[out] OutputJson          Patched JSON data on output.
+
+  @retval     EFI_SUCCESS         OutputJson is returned successfully.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+RedfishPatchSchemaVersion (
+  IN REDFISH_SCHEMA_INFO  *SchemaInfo,
+  IN CHAR8                *InputJson,
+  OUT CHAR8               **OutputJson
+  );
+
 #endif

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigInternal.h
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigInternal.h
@@ -1,7 +1,7 @@
 /** @file
   Header file of EDKII Redfish Resource Config Library.
 
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -20,6 +20,7 @@
 #include <Library/RedfishFeatureUtilityLib.h>
 #include <Library/RedfishPlatformConfigLib.h>
 #include <Library/RedfishHttpLib.h>
+#include <Library/PrintLib.h>
 
 ///
 /// Definition of EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOLS
@@ -36,9 +37,12 @@ typedef struct {
   EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOLS    RedfishResourceConfig;
   EFI_HANDLE                                 CachedHandle;
   REDFISH_SCHEMA_INFO                        SchemaInfoCache;
+  BOOLEAN                                    CompatibleMode;
 } REDFISH_CONFIG_PROTOCOL_CACHE;
 
 #define SCHEMA_NAME_PREFIX         "x-UEFI-redfish-"
 #define SCHEMA_NAME_PREFIX_OFFSET  (AsciiStrLen (SCHEMA_NAME_PREFIX))
+#define SCHEMA_ODATA_TYPE          "@odata.type"
+#define SCHEMA_ODATA_TYPE_MAX_LEN  64
 
 #endif

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.inf
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.inf
@@ -41,6 +41,7 @@
   RedfishFeatureUtilityLib
   RedfishPlatformConfigLib
   RedfishHttpLib
+  PrintLib
 
 [Protocols]
   gEdkIIRedfishResourceConfigProtocolGuid         ## CONSUMES ##
@@ -50,4 +51,4 @@
 [Pcd]
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
-
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport

--- a/RedfishClientPkg/RedfishClientPkg.dec
+++ b/RedfishClientPkg/RedfishClientPkg.dec
@@ -75,6 +75,8 @@
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishSystemRebootTimeout|5|UINT16|0x20000002
   ## Default capability of Redfish service side ETAG support
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishServiceEtagSupported|TRUE|BOOLEAN|0x10000005
+  # Support newer schema version with old schema version driver.
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport|TRUE|BOOLEAN|0x20000006
 
 [PcdsDynamicEx]
   ## The flag used to indicate that system reboot is required due to system configuration change


### PR DESCRIPTION
In UEFI Redfish design, for each different Redfish schema type and version, there will be a driver to support each of them. This create 1:1 mapping between schema version and UEFI image. Per rule in Redfish schema, there is no issue to support new schema version with old schema version.

We need an enhancement done in UEFI Redfish design so we can decouple BMC FW and BIOS FW from FW release perspective.